### PR TITLE
Add changes to scale the effective batch size of the model

### DIFF
--- a/comments.md
+++ b/comments.md
@@ -70,10 +70,10 @@ In particular if we want to run on 4 GPUs on one node we need to make sure that 
 #SBATCH --ntasks-per-node=4   # ntasks needs to be same as n_gpus
 ```
 
-An example of a job-script for training using multiple GPUs can be found in `examples/example_multi_gpu.sh`
+An example of a job-script for training using multiple GPUs can be found in [examples/example_multi_gpu.sh](https://github.com/astro-informatics/rcGAN/blob/dev-multiGPU/examples/example_multi_gpu_train.sh)
 
 ## Batch size tuning
-Additionally I have created a script, `find_batch_size.py` that finds the largest batch_size that you can run per GPU. This depends on the VRAM available on the GPU and can therefore vary accross machines/nodes. An example job file can be found in `examples/example_find_batch_size.sh`. Usage is:
+Additionally I have created a script, [find_batch_size.py](https://github.com/astro-informatics/rcGAN/blob/dev-multiGPU/find_batch_size.py) that finds the largest batch_size that you can run per GPU. This depends on the VRAM available on the GPU and can therefore vary accross machines/nodes. An example job file can be found in [examples/example_find_batch_size.sh](https://github.com/astro-informatics/rcGAN/blob/dev-multiGPU/examples/example_find_batch_size.sh). Usage is:
 
 ```
 python find_batch_size.py --config [config_file.yml]

--- a/comments.md
+++ b/comments.md
@@ -60,3 +60,30 @@ If disk space is a concern, 50 can be reduced to 25.
 This is important for the next step, validation.
 
 
+## Multi-GPU Runs
+To make the lightning module work on multiple GPUs (and on multiple nodes) when using the SLURM workload manager, we need to be careful in setting up the SLURM job script. An example of how to do this can be found here https://pytorch-lightning.readthedocs.io/en/1.2.10/clouds/slurm.html. 
+
+In particular if we want to run on 4 GPUs on one node we need to make sure that we ask for 4 GPUs as well as 4 tasks (since lightning will create 1 task per GPU) per node:
+
+```
+#SBATCH --gres=gpu:4          # n_gpus
+#SBATCH --ntasks-per-node=4   # ntasks needs to be same as n_gpus
+```
+
+An example of a job-script for training using multiple GPUs can be found in `examples/example_multi_gpu.sh`
+
+## Batch size tuning
+Additionally I have created a script, `find_batch_size.py` that finds the largest batch_size that you can run per GPU. This depends on the VRAM available on the GPU and can therefore vary accross machines/nodes. An example job file can be found in `examples/example_find_batch_size.sh`. Usage is:
+
+```
+python find_batch_size.py --config [config_file.yml]
+```
+
+Finally, to support larger batch sizes we can accumulate the gradients over batch sizes. In order to enable this and set the amount of accumulation you can add to your config file:
+
+```
+batch_size: 8               # batch_size per GPU (because of DDP)
+accumulate_grad_batches: 2  # updates model after 2 batches per GPU
+```
+
+When using the distributed data processing (DDP) training strategy, the model is copied exactly on each GPU and they all see only a part of the data during the epoch. After processing 1 batch on each of the GPUs, the gradients from each of the GPUs are averaged and the models are updated. If we use gradient accumulation the gradients are instead averaged over several of such steps. The effective batch size of the model is therefore: n_gpus * batch_size *  accumulate_grad_batches. 

--- a/configs/radio_image_test.yml
+++ b/configs/radio_image_test.yml
@@ -26,9 +26,10 @@ gp_weight: 10
 adv_weight: 1e-5
 
 # Training
-batch_size: 8
+batch_size: 4
+accumulate_grad_batches: 2
 #Remember to increase this for full training
-num_epochs: 100
+num_epochs: 1
 psnr_gain_tol: 0.25
 
-num_workers: 4
+num_workers: 1

--- a/examples/example_find_batch_size.sh
+++ b/examples/example_find_batch_size.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#SBATCH --job-name=find_batch_size
+#SBATCH -p GPU
+#SBATCH --nodelist=compute-gpu-0-2
+# requesting one node, one gpu
+#SBATCH --nodes=1
+#SBATCH --gres=gpu:1    # requesting GPUs
+#SBATCH --ntasks-per-node=1
+#SBATCH --output=find_batch_size_%j.out
+#SBATCH --error=find_batch_size_%j.err
+
+# Finding batch size only on one GPU
+# Make sure to specifiy the node and/or kind of GPU you want to train the full model on.
+
+# Load conda and activate environment
+source /share/apps/anaconda/3-2022.05/etc/profile.d/conda.sh
+conda activate cGAN
+
+export WANDB_DIR=/share/gpu0/mars/wandb/logs
+export WANDB_CACHE_DIR=/share/gpu0/mars/wandb/.cache/wandb
+export WANDB_CONFIG_DIR=/share/gpu0/mars/wandb/.config/wandb
+
+# Echo commands
+set -x
+
+echo $CUDA_VISIBLE_DEVICES
+echo $WANDB_DIR
+echo $WANDB_CACHE_DIR
+echo $WANDB_CONFIG_DIR
+
+cd /home/mars/git/rcGAN
+
+# make sure to run on only 1 GPU
+srun python -u  find_batch_size.py --config ./configs/radio_image_test.yml --num-gpus 1
+
+

--- a/examples/example_multi_gpu_train.sh
+++ b/examples/example_multi_gpu_train.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#SBATCH --job-name=multi_gpu_train
+#SBATCH -p GPU
+
+# request specific node
+#SBATCH --nodelist=compute-gpu-0-2
+# requesting one node, GPUs
+#SBATCH --nodes=1
+#SBATCH --gres=gpu:4          # n_gpus
+#SBATCH --ntasks-per-node=4   # ntasks needs to be same as n_gpus
+
+#SBATCH --output=multi_gpu_train_%j.out
+#SBATCH --error=multi_gpu_train_%j.err
+
+#SBATCH -n16
+#SBATCH --cpus-per-task=4       # 4 cpus per task
+
+##SBATCH --mail-use=
+##SBATCH --mail-type=ALL
+
+
+# Load conda and activate environment
+source /share/apps/anaconda/3-2022.05/etc/profile.d/conda.sh
+conda activate cGAN
+
+export WANDB_DIR=/share/gpu0/mars/wandb/logs
+export WANDB_CACHE_DIR=/share/gpu0/mars/wandb/.cache/wandb
+export WANDB_CONFIG_DIR=/share/gpu0/mars/wandb/.config/wandb
+
+# Echo commands
+set -x
+
+echo $CUDA_VISIBLE_DEVICES
+echo $WANDB_DIR
+echo $WANDB_CACHE_DIR
+echo $WANDB_CONFIG_DIR
+
+cd /home/mars/git/rcGAN
+
+srun python -u  train.py --config ./configs/radio_image_test.yml --exp-name radio_train_test --num-gpus 4
+


### PR DESCRIPTION
Closes #1 

Adds methods to scale up the effective batch size of the model. This includes a script to find the largest batch size that fits on your current GPU; `find_batch_size.py`. Also it includes the option to accumulate gradients over several batches by setting in the config file: 

```
batch_size: 8
accumulate_grad_batches: 2 # only updates model after 2 batches per GPU
```

The effective batch size of the model is then: n_gpus * batch_size *  accumulate_grad_batches. 

A more detailed description of how the model runs on the multiple GPUs can be found in #1 